### PR TITLE
Improve theme switching and type hints

### DIFF
--- a/ui/add_page.py
+++ b/ui/add_page.py
@@ -14,7 +14,9 @@ def add_page(
     on_back: Callable[[], None],
     known_accounts: Optional[List[str]] = None,
     known_categories: Optional[List[str]] = None,
-):
+) -> None:
+    """Render the page for adding a new entry."""
+
     _section_header_with_back(t("add_title"), t, on_back, key="add_top")
 
     today = st.session_state.get("_today_cache")
@@ -121,7 +123,8 @@ def add_page(
 
 
 # ------- Helper -------
-def _section_header_with_back(title: str, t, on_back, key: str):
+def _section_header_with_back(title: str, t: Callable[[str], str], on_back: Callable[[], None], key: str) -> None:
+    """Render a section header with a back button on the right."""
     c1, c2 = st.columns([6, 1])
     with c1:
         st.subheader(title)
@@ -130,23 +133,33 @@ def _section_header_with_back(title: str, t, on_back, key: str):
             on_back()
             st.rerun()
 
-def _bottom_right_back(t, on_back, key: str):
+
+def _bottom_right_back(t: Callable[[str], str], on_back: Callable[[], None], key: str) -> None:
+    """Render a back button aligned to the bottom right."""
     c1, c2 = st.columns([5, 1])
     with c2:
         if st.button("⬅️ " + t("back"), key=f"back_bottom_{key}", use_container_width=True):
             on_back()
             st.rerun()
 
-def _is_custom_label(label: str, lang: str, t) -> bool:
+
+def _is_custom_label(label: str, lang: str, t: Callable[[str], str]) -> bool:
+    """Return True if the cycle label represents a custom value."""
     return label == t("custom_cycle_label") or label in ("Benutzerdefiniert", "Custom")
 
-def _is_custom_account(label: str, lang: str, t) -> bool:
+
+def _is_custom_account(label: str, lang: str, t: Callable[[str], str]) -> bool:
+    """Return True if the account label represents a custom account."""
     return label == t("custom_account_label") or label in ("Neues Konto", "New account")
 
-def _is_custom_category(label: str, lang: str, t) -> bool:
+
+def _is_custom_category(label: str, lang: str, t: Callable[[str], str]) -> bool:
+    """Return True if the category label represents a custom category."""
     return label == t("custom_category_label") or label in ("Neue Kategorie", "New category")
 
+
 def _pref_idx(labels: List[str], default_label: str) -> int:
+    """Return the index of the default label or 0 if not found."""
     try:
         return labels.index(default_label)
     except ValueError:

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -3,22 +3,35 @@ from __future__ import annotations
 import streamlit as st
 import plotly.io as pio
 
-def set_plotly_theme(theme: str):
-    """Plotly-Template passend zum App-Theme umschalten."""
+
+def set_plotly_theme(theme: str) -> None:
+    """Switch the default Plotly template to match the app theme."""
     pio.templates.default = "plotly_dark" if theme == "dark" else "plotly"
 
-def inject_theme_css(theme: str):
-    """Konsistentes Light/Dark/System-CSS (Buttons, Inputs, Selects), überschreibt frühere Styles sicher."""
+
+def inject_theme_css(theme: str) -> None:
+    """Inject consistent CSS for light, dark and system themes.
+
+    Existing theme styles are replaced and buttons now use the accent color
+    for their background to ensure a visible primary action.
+    """
+
+    # Remove previously injected theme, if any
+    st.markdown(
+        "<script>var el=document.getElementById('rp-theme');if(el) el.remove();</script>",
+        unsafe_allow_html=True,
+    )
+
     DARK = """
     <style id="rp-theme">
     :root { --bg:#0f1117; --card:#151a23; --fg:#e7e7e7; --muted:#a0a5ac; --border:#2a3140; --accent:#4c8bf5; }
     .stApp { background: var(--bg) !important; color: var(--fg) !important; }
     div[data-testid="stHeader"] { background: var(--card) !important; }
     .stButton>button, .stDownloadButton>button {
-      background: var(--card) !important; color: var(--fg) !important;
-      border: 1px solid var(--border) !important; border-radius: 12px !important;
+      background: var(--accent) !important; color: #fff !important;
+      border: 1px solid var(--accent) !important; border-radius: 12px !important;
     }
-    .stButton>button:hover, .stDownloadButton>button:hover { border-color: var(--accent) !important; }
+    .stButton>button:hover, .stDownloadButton>button:hover { filter: brightness(1.1); }
     .stTextInput input, .stNumberInput input, .stTextArea textarea,
     .stDateInput input, .stTimeInput input,
     .stSelectbox div[role="combobox"], .stMultiSelect div[role="combobox"] {
@@ -38,10 +51,10 @@ def inject_theme_css(theme: str):
     .stApp { background: var(--bg) !important; color: var(--fg) !important; }
     div[data-testid="stHeader"] { background: var(--card) !important; }
     .stButton>button, .stDownloadButton>button {
-      background: var(--card) !important; color: var(--fg) !important;
-      border: 1px solid var(--border) !important; border-radius: 12px !important;
+      background: var(--accent) !important; color: #fff !important;
+      border: 1px solid var(--accent) !important; border-radius: 12px !important;
     }
-    .stButton>button:hover, .stDownloadButton>button:hover { border-color: var(--accent) !important; }
+    .stButton>button:hover, .stDownloadButton>button:hover { filter: brightness(0.9); }
     .stTextInput input, .stNumberInput input, .stTextArea textarea,
     .stDateInput input, .stTimeInput input,
     .stSelectbox div[role="combobox"], .stMultiSelect div[role="combobox"] {
@@ -62,10 +75,10 @@ def inject_theme_css(theme: str):
       .stApp { background: var(--bg) !important; color: var(--fg) !important; }
       div[data-testid="stHeader"] { background: var(--card) !important; }
       .stButton>button, .stDownloadButton>button {
-        background: var(--card) !important; color: var(--fg) !important;
-        border: 1px solid var(--border) !important; border-radius: 12px !important;
+        background: var(--accent) !important; color: #fff !important;
+        border: 1px solid var(--accent) !important; border-radius: 12px !important;
       }
-      .stButton>button:hover, .stDownloadButton>button:hover { border-color: var(--accent) !important; }
+      .stButton>button:hover, .stDownloadButton>button:hover { filter: brightness(1.1); }
       .stTextInput input, .stNumberInput input, .stTextArea textarea,
       .stDateInput input, .stTimeInput input,
       .stSelectbox div[role="combobox"], .stMultiSelect div[role="combobox"] {

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -1,11 +1,18 @@
 import streamlit as st
+from typing import Callable
 
-def render_topbar(t, unread_count: int, username: str | None):
-    st.markdown("""
+
+def render_topbar(t: Callable[[str], str], unread_count: int, username: str | None) -> None:
+    """Render the application top bar with navigation buttons."""
+
+    st.markdown(
+        """
     <style>
     div.stButton > button { padding: 0.28rem 0.55rem; border-radius: 10px; }
     </style>
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
 
     topbar = st.container()
     with topbar:


### PR DESCRIPTION
## Summary
- Revamp theme injection to apply accent-colored buttons and cleanly replace previous styles
- Add type hints and docstrings for top bar and add-entry helpers