### PR TITLE
Remove custom theme CSS injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ venv/
 
 # Local config / secrets (falls später genutzt)
 .env
-.streamlit/
+/.streamlit/*
+!/.streamlit/config.toml
 
 # OS cruft
 .DS_Store

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[theme]
+base = "light"
+primaryColor = "#316bd8"

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ from ui.add_page import add_page
 from ui.charts import saldo_chart
 from ui.dialogs import notifications_page, settings_page
 from ui.edit_page import edit_page
-from ui.theme import inject_theme_css, set_plotly_theme
+from ui.theme import inject_mobile_only_css, set_plotly_theme
 from ui.topbar import render_topbar
 
 # -------------------------------
@@ -281,10 +281,8 @@ TURNUS_LABELS = list(TURNUS_MAPPING.keys())
 if st.session_state.get("route") in ("add", "edit"):  # optional – nur auf Add/Edit
     inject_mobile_only_css()
 
-# Aufrufen, nachdem du prefs gelesen hast:
-theme = prefs.get("theme", "light")
-inject_theme_css(theme)
-set_plotly_theme(theme)
+# Sync Plotly template with the active Streamlit theme
+set_plotly_theme(st.get_option("theme.base"))
 
 st.title(f"📊 {t('app_title')} · v{get_version()}")
 

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -4,7 +4,6 @@ import json, streamlit as st
 from datetime import datetime
 
 from typing import Callable, Optional, Dict, List
-from ui.theme import inject_theme_css, set_plotly_theme
 
 
 
@@ -94,33 +93,6 @@ def settings_page(
                 })
                 st.success(t("saved"))
                 st.rerun()
-
-        st.markdown("---")
-
-        cur_theme = prefs.get("theme", "light")  # default
-
-        theme_labels = {
-            "light": t("theme_light"),
-            "dark": t("theme_dark"),
-            "system": t("theme_system"),
-        }
-        theme_values = list(theme_labels.keys())
-        theme_display = [theme_labels[v] for v in theme_values]
-
-        try:
-            idx = theme_values.index(cur_theme)
-        except ValueError:
-            idx = 0
-
-        sel = st.selectbox(t("theme"), theme_display, index=idx, key="ui_theme")
-        new_theme = theme_values[theme_display.index(sel)]
-
-        if new_theme != cur_theme:
-            prefs_updater({"theme": new_theme})
-            inject_theme_css(new_theme)
-            set_plotly_theme(new_theme)      
-            st.toast(t("saved"), icon="✅")
-            st.rerun()    
 
         st.markdown("---")
 


### PR DESCRIPTION
## Summary
- rely on Streamlit's built-in theming instead of injecting CSS
- configure light theme and accent color via `.streamlit/config.toml`
- drop manual theme picker and sync Plotly with the active Streamlit theme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0996c1c88327ba69295082bc8fce