### PR TITLE
feat: allow switching Streamlit theme at runtime

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ from ui.charts import saldo_chart
 from ui.dialogs import notifications_page, settings_page
 from ui.edit_page import edit_page
 from ui.topbar import render_topbar
+from ui.theme import set_plotly_theme
 
 # -------------------------------
 # Settings & i18n
@@ -281,8 +282,8 @@ if st.session_state.get("route") in ("add", "edit"):  # optional – nur auf Add
     inject_mobile_only_css()
 
 # Use Streamlit's built-in theming (no custom CSS injection)
-# theme = prefs.get("theme", "light")
-# set_plotly_theme(theme)
+theme = prefs.get("theme", "light")
+set_plotly_theme(theme)
 
 st.title(f"📊 {t('app_title')} · v{get_version()}")
 

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -4,7 +4,7 @@ import json, streamlit as st
 from datetime import datetime
 
 from typing import Callable, Optional, Dict, List
-from ui.theme import set_plotly_theme
+from ui.theme import set_streamlit_theme
 
 
 
@@ -117,9 +117,8 @@ def settings_page(
 
         if new_theme != cur_theme:
             prefs_updater({"theme": new_theme})
-            set_plotly_theme(new_theme)
             st.toast(t("saved"), icon="✅")
-            st.rerun()
+            set_streamlit_theme(new_theme)
 
         st.markdown("---")
 

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,12 +1,31 @@
 # ui/theme.py
 from __future__ import annotations
-import streamlit as st
+
+import re
+from pathlib import Path
+
 import plotly.io as pio
+import streamlit as st
 
 
 def set_plotly_theme(theme: str) -> None:
     """Switch the default Plotly template to match the app theme."""
     pio.templates.default = "plotly_dark" if theme == "dark" else "plotly"
+
+
+def set_streamlit_theme(theme: str) -> None:
+    """Update Streamlit's theme setting and trigger a rerun."""
+    cfg_path = Path(__file__).resolve().parent.parent / ".streamlit" / "config.toml"
+    text = cfg_path.read_text(encoding="utf-8")
+    if "base" in text:
+        text = re.sub(r'base\s*=\s*"(light|dark)"', f'base = "{theme}"', text)
+    elif "[theme]" in text:
+        text = text.replace("[theme]", f"[theme]\nbase = \"{theme}\"")
+    else:
+        text += f"\n[theme]\nbase = \"{theme}\""
+    cfg_path.write_text(text, encoding="utf-8")
+    set_plotly_theme(theme)
+    st.rerun()
 
 
 def inject_theme_css(theme: str) -> None:


### PR DESCRIPTION
## Summary
- add `set_streamlit_theme` to rewrite `.streamlit/config.toml` and rerun
- integrate theme switch into settings dialog
- apply saved theme to Plotly on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f147f73508327962ad96067c69a3c