### PR TITLE
fix: guard notification evaluation for entries without next due date

### DIFF
--- a/core/notify.py
+++ b/core/notify.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date, timedelta
 from typing import List, Dict, Tuple
-from i18n import MONTHS
+from i18n import MONTHS, get_text
 from .calc import get_next_due_text
 from .cycles import safe_cycle_months, months_to_next_occurrence
 
@@ -135,17 +135,18 @@ def evaluate_events(entries: list[dict], rules, lang: str, today: date | None = 
         # Nächste Fälligkeit
         if rules["due_upcoming"].enabled:
             months = months_to_next_occurrence(e, lang)
-            # Einfacher Ansatz: wenn innerhalb lead_days
-            # (aus months grob in Tage umrechnen):
-            days = int(months * 30)  # pragmatisch
-            if 0 <= days <= rules["due_upcoming"].lead_days:
-                out.append({
-                    "type": "due_upcoming",
-                    "entry_id": e["id"],
-                    "title": t("notif_due_upcoming_title").format(name=e["name"]),
-                    "read": False,
-                    "ts": today.isoformat(),
-                })
+            if months is not None:
+                # Einfacher Ansatz: wenn innerhalb lead_days
+                # (aus months grob in Tage umrechnen):
+                days = int(months * 30)  # pragmatisch
+                if 0 <= days <= rules["due_upcoming"].lead_days:
+                    out.append({
+                        "type": "due_upcoming",
+                        "entry_id": e["id"],
+                        "title": get_text(lang, "notif_due_upcoming_title").format(name=e["name"]),
+                        "read": False,
+                        "ts": today.isoformat(),
+                    })
 
         # Enddatum
         if rules["end_upcoming"].enabled and (end := e.get("end_date")):
@@ -158,7 +159,7 @@ def evaluate_events(entries: list[dict], rules, lang: str, today: date | None = 
                     out.append({
                         "type": "end_upcoming",
                         "entry_id": e["id"],
-                        "title": t("notif_end_upcoming_title").format(name=e["name"], end=end),
+                        "title": get_text(lang, "notif_end_upcoming_title").format(name=e["name"], end=end),
                         "read": False,
                         "ts": today.isoformat(),
                     })

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,25 @@
+from datetime import date
+from unittest.mock import patch
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.notify import evaluate_events
+from core.notify_rules import DEFAULT_RULES
+from i18n import get_text
+
+
+def test_evaluate_events_skips_when_no_next_due():
+    entries = [{"id": "1", "name": "Test"}]
+    with patch("core.notify.months_to_next_occurrence", return_value=None):
+        events = evaluate_events(entries, DEFAULT_RULES, "de", today=date(2024, 1, 1))
+    assert events == []
+
+
+def test_evaluate_events_generates_translated_title():
+    entries = [{"id": "2", "name": "Foo"}]
+    with patch("core.notify.months_to_next_occurrence", return_value=0):
+        events = evaluate_events(entries, DEFAULT_RULES, "de", today=date(2024, 1, 1))
+    assert events[0]["title"] == get_text("de", "notif_due_upcoming_title").format(name="Foo")
+


### PR DESCRIPTION
## Summary
- avoid TypeError when evaluating events with entries that have no upcoming due date
- use built-in localization for notification titles
- cover evaluation logic with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71522dbe8832782e7a5ffe293a1a0