### PR TITLE
Fix due month sorting and ensure savings complete before due date

### DIFF
--- a/core/calc.py
+++ b/core/calc.py
@@ -106,6 +106,8 @@ def calculate_monthly_saving_and_progress(entry: Dict, lang: str) -> Tuple[float
 
     # innerhalb des aktuellen Zyklus: wie viele Monate bereits vergangen?
     months_saved = (today.year - cycle_start.year) * 12 + (today.month - cycle_start.month)
+    if today >= cycle_start:
+        months_saved += 1
     months_saved = max(0, min(months_saved, months_total))
 
     rate = amount / months_total if months_total and months_total > 0 else 0.0

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Tuple
+
+
+def _normalize_due_month(entry: Dict) -> int:
+    """Return the due month for an entry as an integer between 1 and 12."""
+    try:
+        month = int(entry.get("due_month") or 0)
+    except (TypeError, ValueError):
+        month = 0
+    if 1 <= month <= 12:
+        return month
+    start = entry.get("start_date") or ""
+    try:
+        return int(start.split("-")[1])
+    except (IndexError, ValueError):
+        return datetime.now().month
+
+
+def due_month_sort_value(entry: Dict, reference_month: int | None = None) -> Tuple[int, int, str]:
+    """Return a tuple that can be used to sort entries by due month.
+
+    The tuple rotates months so that sorting starts with the month nearest to the
+    provided reference month (default: the current month).
+    """
+
+    ref = reference_month or datetime.now().month
+    due_month = _normalize_due_month(entry)
+    rotation = (due_month - ref) % 12
+    name = (entry.get("name") or "").lower()
+    return rotation, due_month, name

--- a/core/utils.py
+++ b/core/utils.py
@@ -19,15 +19,39 @@ def _normalize_due_month(entry: Dict) -> int:
         return datetime.now().month
 
 
-def due_month_sort_value(entry: Dict, reference_month: int | None = None) -> Tuple[int, int, str]:
-    """Return a tuple that can be used to sort entries by due month.
+def next_month_start(from_date: datetime | None = None) -> datetime:
+    base = (from_date or datetime.now()).replace(day=1)
+    year = base.year + (1 if base.month == 12 else 0)
+    month = 1 if base.month == 12 else base.month + 1
+    return datetime(year, month, 1)
 
-    The tuple rotates months so that sorting starts with the month nearest to the
-    provided reference month (default: the current month).
-    """
 
-    ref = reference_month or datetime.now().month
-    due_month = _normalize_due_month(entry)
-    rotation = (due_month - ref) % 12
+def due_month_sort_value(
+    entry: Dict,
+    reference: datetime | None = None,
+    lang: str = "de",
+) -> Tuple[float, int, str, str]:
+    """Return a tuple that can be used to sort entries by their upcoming due date."""
+
+    from core.calc import get_next_due_date
+
+    ref = reference or next_month_start()
+    ref = ref.replace(day=1)
+
+    try:
+        next_due = get_next_due_date(entry, lang)
+    except (KeyError, ValueError):
+        next_due = None
+    if next_due:
+        due_date = next_due.replace(day=1)
+    else:
+        due_month = _normalize_due_month(entry)
+        due_date = datetime(ref.year, due_month, 1)
+        while due_date < ref:
+            due_date = datetime(due_date.year + 1, due_date.month, 1)
+
+    months_ahead = (due_date.year - ref.year) * 12 + (due_date.month - ref.month)
+    account = (entry.get("konto") or "").lower()
     name = (entry.get("name") or "").lower()
-    return rotation, due_month, name
+
+    return float(months_ahead), due_date.month, account, name

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ from core.storage import (
     get_categories as storage_get_categories,
     ensure_streamlit_config,
 )
-from core.utils import due_month_sort_value
+from core.utils import due_month_sort_value, next_month_start
 
 from ui.add_page import add_page
 from ui.charts import saldo_chart
@@ -456,8 +456,8 @@ with tab1:
                 and _match(e.get("konto", ""), selected_konto)]
 
     if sort_option == t("sort_due_month"):
-        current_month = datetime.now().month
-        filtered.sort(key=lambda x: due_month_sort_value(x, current_month))
+        reference = next_month_start(datetime.now())
+        filtered.sort(key=lambda x: due_month_sort_value(x, reference, LANG))
     elif sort_option == t("sort_monthly"):
         filtered.sort(key=lambda x: calculate_monthly_saving_and_progress(x, LANG)[0], reverse=True)
     else:

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ from core.storage import (
     get_categories as storage_get_categories,
     ensure_streamlit_config,
 )
+from core.utils import due_month_sort_value
 
 from ui.add_page import add_page
 from ui.charts import saldo_chart
@@ -455,7 +456,8 @@ with tab1:
                 and _match(e.get("konto", ""), selected_konto)]
 
     if sort_option == t("sort_due_month"):
-        filtered.sort(key=lambda x: int(x["due_month"]))
+        current_month = datetime.now().month
+        filtered.sort(key=lambda x: due_month_sort_value(x, current_month))
     elif sort_option == t("sort_monthly"):
         filtered.sort(key=lambda x: calculate_monthly_saving_and_progress(x, LANG)[0], reverse=True)
     else:

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -49,6 +49,39 @@ def test_due_month_sort_value_wraps_year():
         {"name": "C", "due_month": 3},
     ]
 
-    ordered = sorted(entries, key=lambda e: due_month_sort_value(e, reference_month=9))
+    reference = datetime(2025, 10, 1)
+    ordered = sorted(entries, key=lambda e: due_month_sort_value(e, reference, "de"))
 
     assert [e["name"] for e in ordered] == ["B", "A", "C"]
+
+
+def test_due_month_sort_uses_next_due_date(monkeypatch):
+    class _FakeDateTime(datetime):
+        @classmethod
+        def now(cls):
+            return datetime(2025, 9, 15)
+
+    monkeypatch.setattr("core.calc.datetime", _FakeDateTime)
+
+    entry_current_year = {
+        "name": "Aktuell",
+        "due_month": 11,
+        "start_date": "2024-01",
+        "cycle": "Jährlich",
+        "amount": 100,
+    }
+    entry_next_year = {
+        "name": "Später",
+        "due_month": 11,
+        "start_date": "2025-12",
+        "cycle": "Jährlich",
+        "amount": 100,
+    }
+
+    reference = datetime(2025, 10, 1)
+    ordered = sorted(
+        [entry_next_year, entry_current_year],
+        key=lambda e: due_month_sort_value(e, reference, "de"),
+    )
+
+    assert [e["name"] for e in ordered] == ["Aktuell", "Später"]

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import core.calc as calc  # noqa: E402
+from core.utils import due_month_sort_value  # noqa: E402
+
+
+class _FixedDateTime(datetime):
+    """Helper datetime subclass that freezes now() for deterministic tests."""
+
+    _NOW = datetime(2025, 9, 1)
+
+    @classmethod
+    def now(cls):
+        return cls._NOW
+
+    @classmethod
+    def strptime(cls, *args, **kwargs):
+        return datetime.strptime(*args, **kwargs)
+
+
+def test_progress_complete_month_before_due(monkeypatch):
+    monkeypatch.setattr(calc, "datetime", _FixedDateTime)
+
+    entry = {
+        "start_date": "2024-10",
+        "due_month": "10",
+        "cycle": "Jährlich",
+        "amount": 900,
+    }
+
+    rate, percent, saved, info = calc.calculate_monthly_saving_and_progress(entry, "de")
+
+    assert rate == pytest.approx(75.0)
+    assert percent == pytest.approx(1.0)
+    assert saved == pytest.approx(entry["amount"])
+    assert info is None
+
+
+def test_due_month_sort_value_wraps_year():
+    entries = [
+        {"name": "A", "due_month": 11},
+        {"name": "B", "due_month": 10},
+        {"name": "C", "due_month": 3},
+    ]
+
+    ordered = sorted(entries, key=lambda e: due_month_sort_value(e, reference_month=9))
+
+    assert [e["name"] for e in ordered] == ["B", "A", "C"]


### PR DESCRIPTION
## Summary
- adjust due month sorting so entries start at the upcoming due month
- ensure monthly savings reach 100% by the month before the due date
- add utilities and tests covering due month sorting and savings progress

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68db7f5d3ffc8327a4e28a941c900e13