### PR TITLE
Fix wrapped encryption key handling

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,23 @@
+import base64
+
+from core.crypto import wrap_key, unwrap_key
+
+
+def test_wrap_key_returns_base64_string_roundtrip():
+    data_key = bytes(range(32))
+    kek = bytes(reversed(range(32)))
+
+    wrapped = wrap_key(data_key, kek)
+
+    assert isinstance(wrapped, str)
+    assert unwrap_key(wrapped, kek) == data_key
+
+
+def test_unwrap_key_accepts_raw_bytes_payload():
+    data_key = b"a" * 32
+    kek = b"b" * 32
+
+    wrapped_str = wrap_key(data_key, kek)
+    wrapped_bytes = base64.b64decode(wrapped_str.encode("ascii"))
+
+    assert unwrap_key(wrapped_bytes, kek) == data_key


### PR DESCRIPTION
## Summary
- return base64-encoded data from `core.crypto.wrap_key` and allow `unwrap_key` to accept stored strings
- add regression tests to ensure wrapped keys round-trip correctly from both string and byte representations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbbd09a5b08327a22ded607e6897ff